### PR TITLE
Got rid of Python-fontconfig since it didn't do what we needed. Added…

### DIFF
--- a/octoprint_octolapse/__init__.py
+++ b/octoprint_octolapse/__init__.py
@@ -28,7 +28,6 @@ import json
 import os
 import shutil
 from distutils.version import LooseVersion
-import fontconfig
 
 import flask
 import octoprint.plugin
@@ -345,7 +344,7 @@ class OctolapsePlugin(octoprint.plugin.SettingsPlugin,
     @restricted_access
     @admin_permission.require(403)
     def get_available_fonts(self):
-        font_list = fontconfig.query()
+        font_list = utility.get_system_fonts()
         return json.dumps(font_list), 200, {'ContentType': 'application/json'}
 
     @octoprint.plugin.BlueprintPlugin.route("/rendering/watermark", methods=["GET"])

--- a/octoprint_octolapse/test/test_render.py
+++ b/octoprint_octolapse/test/test_render.py
@@ -20,7 +20,6 @@
 # You can contact the author either through the git-hub repository, or at the
 # following email address: FormerLurker@pm.me
 ##################################################################################
-import fontconfig
 import os
 import os.path
 import random
@@ -40,7 +39,7 @@ from mock import Mock
 from octoprint_octolapse.render import TimelapseRenderJob, Render, Rendering
 from octoprint_octolapse.settings import OctolapseSettings
 from octoprint_octolapse.snapshot import METADATA_FILE_NAME, METADATA_FIELDS
-from octoprint_octolapse.utility import get_snapshot_filename, SnapshotNumberFormat
+from octoprint_octolapse.utility import get_snapshot_filename, SnapshotNumberFormat, get_system_fonts
 
 
 class TestRender(unittest.TestCase):
@@ -274,7 +273,7 @@ class TestRender(unittest.TestCase):
         # Create the job.
         r = Rendering(guid=uuid.uuid4(), name="Render with overlay")
         r.update({'overlay_text_template': "Current Time: {current_time}\nTime elapsed: {time_elapsed}",
-                  'overlay_font_path': fontconfig.query()[0].file})
+                  'overlay_font_path': get_system_fonts()[0]})
         job = self.createRenderingJob(rendering=r)
 
         # Start the job.

--- a/octoprint_octolapse/utility.py
+++ b/octoprint_octolapse/utility.py
@@ -25,6 +25,7 @@ import math
 import ntpath
 import os
 import re
+import subprocess
 import sys
 import time
 import traceback
@@ -477,3 +478,16 @@ def exception_to_string(e):
         return str(e)
     tb_lines = traceback.format_exception(e.__class__, e, trace_back)
     return ''.join(tb_lines)
+
+
+def get_system_fonts():
+    """Retrieves a list of fonts for any operating system. Note that this may not be a complete list of fonts discoverable on the system.
+    :returns A list of filepaths to fonts available on the system."""
+    if sys.platform == "linux" or sys.platform == "linux2" or sys.platform == "darwin":
+        # Linux and OS X.
+        return subprocess.check_output("fc-list --format %{file}\\n".split()).split('\n')
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        # Windows.
+        return [os.path.join(os.environ['WINDIR'], f) for f in os.listdir(os.path.join(os.environ['WINDIR'], "fonts"))]
+    else:
+        raise NotImplementedError('Unsupported operating system.')

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ plugin_url = "https://github.com/FormerLurker/Octolapse"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["pillow", "sarge", "six", "OctoPrint>1.3.8", "Python-fontconfig"]
+plugin_requires = ["pillow", "sarge", "six", "OctoPrint>1.3.8"]
 
 # --------------------------------------------------------------------------------------------------------------------
 # More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
… a function that searches likely places on each platform to find fonts.

Haven't tested on OS X, but I assume it works similarly to Linux.