### PR TITLE
Added vanilla OctoPrint MovieDone event call.

### DIFF
--- a/octoprint_octolapse/__init__.py
+++ b/octoprint_octolapse/__init__.py
@@ -52,7 +52,7 @@ from distutils.version import LooseVersion
 from io import BytesIO
 import octoprint.plugin
 import octoprint.filemanager
-from octoprint.events import Events, eventManager
+from octoprint.events import Events
 from octoprint.server.util.flask import restricted_access
 import octoprint_octolapse.stabilization_preprocessing
 import octoprint_octolapse.camera as camera
@@ -3453,12 +3453,6 @@ class OctolapsePlugin(
             # This timelapse won't be moved into the octoprint timelapse plugin folder.
             message = "Octolapse has completed rendering a timelapse for camera '{0}'.  Your video can be found by  " \
                       "clicking 'Videos and Images' within the Octolapse tab.".format(payload.CameraName)
-            # Call Movie Done
-            eventManager().fire(Events.MOVIE_DONE, {
-                'gcode': payload.gcode_filename,
-                'movie': payload.rendering_path,
-                'movie_basename': payload.rendering_filename
-            })
 
             if payload.ArchivePath and os.path.isfile(payload.ArchivePath):
                 message += "  An archive of your snapshots can be found within the 'Saved Snapshots' tab of the " \
@@ -3507,6 +3501,7 @@ class OctolapsePlugin(
             movie_basename=movie_basename
         )
         self._event_bus.fire(event, payload=custom_payload)
+        self._event_bus.fire(Events.MOVIE_DONE, payload=custom_payload)
 
     def on_render_error(self, payload, error, job):
         """Called after all rendering is complete."""

--- a/octoprint_octolapse/__init__.py
+++ b/octoprint_octolapse/__init__.py
@@ -52,7 +52,7 @@ from distutils.version import LooseVersion
 from io import BytesIO
 import octoprint.plugin
 import octoprint.filemanager
-from octoprint.events import Events
+from octoprint.events import Events, eventManager
 from octoprint.server.util.flask import restricted_access
 import octoprint_octolapse.stabilization_preprocessing
 import octoprint_octolapse.camera as camera
@@ -3453,6 +3453,13 @@ class OctolapsePlugin(
             # This timelapse won't be moved into the octoprint timelapse plugin folder.
             message = "Octolapse has completed rendering a timelapse for camera '{0}'.  Your video can be found by  " \
                       "clicking 'Videos and Images' within the Octolapse tab.".format(payload.CameraName)
+            # Call Movie Done
+            eventManager().fire(Events.MOVIE_DONE, {
+                'gcode': payload.gcode_filename,
+                'movie': payload.rendering_path,
+                'movie_basename': payload.rendering_filename
+            })
+
             if payload.ArchivePath and os.path.isfile(payload.ArchivePath):
                 message += "  An archive of your snapshots can be found within the 'Saved Snapshots' tab of the " \
                            "'Videos and Images' dialog."

--- a/octoprint_octolapse/render.py
+++ b/octoprint_octolapse/render.py
@@ -2379,8 +2379,20 @@ class RenderingCallbackArgs(object):
         self.GcodeFileExtension = gcode_file_extension
         self.RenderingEnabled = rendering_enabled
 
-    def get_rendering_filename(self):
+    @property
+    def gcode_filename(self):
+        return '{0}.{1}'.format(self.GcodeFilename, self.GcodeFileExtension)
+
+    @property
+    def rendering_filename(self):
         return "{0}.{1}".format(self.RenderingFilename, self.RenderingExtension)
 
-    def get_rendering_path(self):
+    @property
+    def rendering_path(self):
         return os.path.join(self.RenderingDirectory, self.get_rendering_filename())
+
+    def get_rendering_filename(self):
+        return self.rendering_filename
+
+    def get_rendering_path(self):
+        return self.rendering_path

--- a/octoprint_octolapse/render.py
+++ b/octoprint_octolapse/render.py
@@ -2379,20 +2379,8 @@ class RenderingCallbackArgs(object):
         self.GcodeFileExtension = gcode_file_extension
         self.RenderingEnabled = rendering_enabled
 
-    @property
-    def gcode_filename(self):
-        return '{0}.{1}'.format(self.GcodeFilename, self.GcodeFileExtension)
-
-    @property
-    def rendering_filename(self):
+    def get_rendering_filename(self):
         return "{0}.{1}".format(self.RenderingFilename, self.RenderingExtension)
 
-    @property
-    def rendering_path(self):
-        return os.path.join(self.RenderingDirectory, self.get_rendering_filename())
-
-    def get_rendering_filename(self):
-        return self.rendering_filename
-
     def get_rendering_path(self):
-        return self.rendering_path
+        return os.path.join(self.RenderingDirectory, self.get_rendering_filename())


### PR DESCRIPTION
This PR added support for calling the `Events.MOVIE_DONE` event on render finish. This allows other plugins hooking that event to trigger appropriately. 

```
2020-02-20 00:42:12,723 - octoprint.util.comm - INFO - Finished in 66.437 s.
2020-02-20 00:42:12,723 - octoprint.util.comm - INFO - Changing monitoring state from "Printing" to "Finishing"
2020-02-20 00:42:12,724 - octoprint.printer.standard.job - INFO - Print job done - origin: local, path: cube.gcode, owner: test
2020-02-20 00:42:13,001 - octoprint.util.comm - INFO - Changing monitoring state from "Finishing" to "Operational"
2020-02-20 00:42:18,551 - octoprint.plugins.dropbox_timelapse - INFO - Uploading cube_20200220004212.mp4 to Dropbox...
2020-02-20 00:42:20,314 - octoprint.plugins.dropbox_timelapse - INFO - Uploaded cube_20200220004212.mp4 to Dropbox!

```