### PR TITLE
Fix sharpness and saturation help prompts

### DIFF
--- a/octoprint_octolapse/static/docs/help/profiles.camera.webcam_settings.mjpg-streamer.options.9963778.md
+++ b/octoprint_octolapse/static/docs/help/profiles.camera.webcam_settings.mjpg-streamer.options.9963778.md
@@ -1,1 +1,1 @@
-Adjust the sharpness of the webcam image.  Lower values have less sharpness, higher values have more.
+Adjust the saturation of the webcam image.  Lower values have less saturation, higher values have more.

--- a/octoprint_octolapse/static/docs/help/profiles.camera.webcam_settings.mjpg-streamer.options.9963803.md
+++ b/octoprint_octolapse/static/docs/help/profiles.camera.webcam_settings.mjpg-streamer.options.9963803.md
@@ -1,1 +1,1 @@
-Adjust the saturation of the webcam image.  Lower values have less saturation, higher values have more.
+Adjust the sharpness of the webcam image.  Lower values have less sharpness, higher values have more.


### PR DESCRIPTION
The help prompts for "Sharpness" and "Saturation" under the custom image preferences were mixed up. 