### PR TITLE
Add timelapse preview to file browser

### DIFF
--- a/octoprint_octolapse/static/js/octolapse.file_browser.js
+++ b/octoprint_octolapse/static/js/octolapse.file_browser.js
@@ -325,5 +325,15 @@ $(function () {
             Octolapse.download(url, e, options);
         };
 
+        self.showTimelapsePreview = function(data) {
+            var url = data.value.get_download_url(data);
+            var previewModal = $("#octolapseTimelapsePreviewModal");
+            previewModal.children("div.modal-body").children("video").attr("src", url);
+            previewModal.off("hidden.bs.modal").on("hidden.bs.modal", function() {
+                $(this).attr("src", "");
+            });
+            previewModal.modal("show");
+        };
+
     };
 });

--- a/octoprint_octolapse/templates/octolapse_dialog_timelapse_files.jinja2
+++ b/octoprint_octolapse/templates/octolapse_dialog_timelapse_files.jinja2
@@ -77,6 +77,9 @@
 </script>
 
 <script type="text/html" id="octolapse-timelapse-files-custom-actions">
+    <a data-bind="click: $data.data.parent.showTimelapsePreview">
+        <i title="Click to preview." class="fa fa-lg fa-camera"></i>
+    </a>&nbsp;|&nbsp;
     <a data-bind="click: $data.data.parent.download">
         <i data-bind="class: $data.data.parent._download_icon_class, attr: {title: $data.data.parent._download_icon_title}" class="fa fa-lg fa-download"></i>
     </a>
@@ -88,4 +91,5 @@
 </script>
 
 {% include "octolapse_file_browser.jinja2" %}
+{% include "octolapse_dialog_timelapse_preview.jinja2" %}
 

--- a/octoprint_octolapse/templates/octolapse_dialog_timelapse_preview.jinja2
+++ b/octoprint_octolapse/templates/octolapse_dialog_timelapse_preview.jinja2
@@ -1,0 +1,12 @@
+<div id="octolapseTimelapsePreviewModal" class="modal large hide fade">
+    <div class="modal-header">
+            <a href="#" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
+            <h3>{{ _('Timelapse Preview') }}</h3>
+    </div>
+    <div class="modal-body" style="text-align: center">
+            <video width="800px" height="600px" style="width: 800px; height: 600px" autoplay controls src=""></video>
+    </div>
+    <div class="modal-footer">
+            <a href="#" class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Close') }}</a>
+    </div>
+</div>


### PR DESCRIPTION
Implementation copied from

https://github.com/OctoPrint/OctoPrint/blob/f67c15a9a47794a68be9aed4f2d5a12a87e70179/src/octoprint/static/js/app/viewmodels/timelapse.js
https://github.com/OctoPrint/OctoPrint/blob/f67c15a9a47794a68be9aed4f2d5a12a87e70179/src/octoprint/templates/dialogs/timelapse.jinja2

There were some access checks in the original file browser which the download in Octolapse didn't have so i didn't add one to the preview

also there were quite some variations for `function() {` so i choose my preferred style