### PR TITLE
Use new PrusaSlicer/SuperSlicer feature comments (removes need for verbose output)

### DIFF
--- a/octoprint_octolapse/data/lib/c/gcode_comment_processor.cpp
+++ b/octoprint_octolapse/data/lib/c/gcode_comment_processor.cpp
@@ -36,6 +36,69 @@ void gcode_comment_processor::update(position& pos)
 
 bool gcode_comment_processor::update_feature_for_slic3r_pe_comment(position& pos, std::string &comment) const
 {
+	// PrusaSlicer / SuperSlicer tags
+	if(comment == "TYPE:Internal perimeter")
+	{
+		pos.feature_type_tag = feature_type_inner_perimeter_feature;
+		return true;
+	}
+	if (comment == "TYPE:External perimeter"
+		|| comment == "TYPE:Thin wall")
+	{
+		pos.feature_type_tag = feature_type_outer_perimeter_feature;
+		return true;
+	}
+	if (comment == "TYPE:Internal infill")
+	{
+		pos.feature_type_tag = feature_type_infill_feature;
+		return true;
+	}
+	if(comment == "TYPE:Solid infill"
+		|| comment == "TYPE:Top solid infill"
+		|| comment == "TYPE:Ironing")
+	{
+		pos.feature_type_tag = feature_type_solid_infill_feature;
+		return true;
+	}
+	if (comment == "TYPE:Gap fill")
+	{
+		pos.feature_type_tag = feature_type_gap_fill_feature;
+		return true;
+	}
+	if (comment == "TYPE:Bridge infill"
+		|| comment == "TYPE:Internal bridge infill"
+		|| comment =="TYPE:Overhang perimeter")
+	{
+		pos.feature_type_tag = feature_type_bridge_feature;
+		return true;
+	}
+	if (comment == "TYPE:Skirt")
+	{
+		pos.feature_type_tag = feature_type_skirt_feature;
+		return true;
+	}
+	if (comment == "TYPE:Support material"
+		|| comment == "TYPE:Support material interface")
+	{
+		// no "support" feature on octolapse. Maybe feature_type_prime_pillar_feature ?
+		pos.feature_type_tag = feature_type_unknown_feature;
+		return true;
+	}
+	if (comment == "TYPE:Wipe tower")
+	{
+		pos.feature_type_tag = feature_type_prime_pillar_feature;
+		return true;
+	}
+	if (comment == "TYPE:Mill"
+		|| comment == "TYPE:Unknown"
+		|| comment == "TYPE:Custom"
+		|| comment == "TYPE:Mixed")
+	{
+		pos.feature_type_tag = feature_type_unknown_feature;
+		return true;
+	}
+
+	// Old slic3r verbose tags
 	if (comment == "perimeter" || comment == "move to first perimeter point")
 	{
 		pos.feature_type_tag = feature_type_unknown_perimeter_feature;


### PR DESCRIPTION
I've been maintaining "verbose" versions of all the default profiles. This probably isn't great if those original profiles are ever updated. It's also not good when I accidentally chose a non-verbose profile.

As of PrusaSlicer/SuperSlicer [2.3](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.3.0-alpha1), feature comments are provided without verbose mode:
> To support visualization of extrusion types and extrusion widths reliably for G-code generated by PrusaSlicer, the G-code generated by PrusaSlicer is newly augmented by the following comments: ";TYPE:", ";HEIGHT:" and ";LAYER_CHANGE", where these comments are only exported when the extrusion type, layer height or layer index changes. In addition, the following annotations are exported for the G-code events inserted on the vertical slider in the G-code viewer: ";COLOR_CHANGE", ";PAUSE_PRINT" and ";CUSTOM_GCODE". G-code generated by older PrusaSlicer which does not contain these new annotations will still be displayed, but the extrusion widths or extrusion types may not be shown reliably.

reference: https://github.com/supermerill/SuperSlicer/issues/739#issuecomment-960343834