### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/octoprint_octolapse/settings.py
+++ b/octoprint_octolapse/settings.py
@@ -113,7 +113,7 @@ class Settings(object):
             return
         item_to_iterate = iterable
 
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections.abc.Iterable):
             to_dict = getattr(iterable, "to_dict", None)
             if callable(to_dict):
                 item_to_iterate = iterable.to_dict()
@@ -1307,7 +1307,7 @@ class MjpgStreamer(StreamingServer):
 
     def update(self, iterable, **kwargs):
         item_to_iterate = iterable
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections.abc.Iterable):
             item_to_iterate = iterable.__dict__
 
         for key, value in item_to_iterate.items():
@@ -1449,7 +1449,7 @@ class WebcamSettings(Settings):
     def update(self, iterable, **kwargs):
         try:
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
 
             for key, value in item_to_iterate.items():
@@ -2072,7 +2072,7 @@ class Profiles(Settings):
 
     def update(self, iterable, **kwargs):
         item_to_iterate = iterable
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections.abc.Iterable):
             item_to_iterate = iterable.__dict__
 
         for key, value in item_to_iterate.items():
@@ -2717,7 +2717,7 @@ class CuraExtruder(SlicerExtruder):
 
     def update(self, iterable, **kwargs):
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -2851,7 +2851,7 @@ class CuraSettings(SlicerSettings):
     def update(self, iterable, **kwargs):
         try:
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -2911,7 +2911,7 @@ class Simplify3dExtruder(SlicerExtruder):
 
     def update(self, iterable, **kwargs):
         item_to_iterate = iterable
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections.abc.Iterable):
             item_to_iterate = iterable.__dict__
         for key, value in item_to_iterate.items():
             class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -3066,7 +3066,7 @@ class Simplify3dSettings(SlicerSettings):
     def update(self, iterable, **kwargs):
         try:
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -3161,7 +3161,7 @@ class Slic3rPeExtruder(SlicerExtruder):
 
     def update(self, iterable, **kwargs):
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -3287,7 +3287,7 @@ class Slic3rPeSettings(SlicerSettings):
     def update(self, iterable, **kwargs):
         try:
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -3348,7 +3348,7 @@ class OtherSlicerExtruder(SlicerExtruder):
 
     def update(self, iterable, **kwargs):
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')
@@ -3407,7 +3407,7 @@ class OtherSlicerSettings(SlicerSettings):
     def update(self, iterable, **kwargs):
         try:
             item_to_iterate = iterable
-            if not isinstance(iterable, collections.Iterable):
+            if not isinstance(iterable, collections.abc.Iterable):
                 item_to_iterate = iterable.__dict__
             for key, value in item_to_iterate.items():
                 class_item = getattr(self, key, '{octolapse_no_property_found}')


### PR DESCRIPTION
Move Iterable to collections.abc (from collections) to fix following error with python 3.10:

```
2022-01-12 19:52:53,512 - octoprint.plugin - ERROR - Error while calling plugin octolapse
Traceback (most recent call last):
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/plugin/__init__.py", line 271, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/util/__init__.py", line 1737, in wrapper
    return f(*args, **kwargs)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/__init__.py", line 2362, in on_startup
    raise e
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/__init__.py", line 2311, in on_startup
    self.load_settings()
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/__init__.py", line 1999, in load_settings
    new_settings, defaults_loaded = OctolapseSettings.load(
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/settings.py", line 2378, in load
    new_settings = OctolapseSettings.create_from_iterable(
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/settings.py", line 2528, in create_from_iterable
    new_object.update(iterable)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/settings.py", line 108, in update
    Settings._update(self, iterable)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_octolapse/settings.py", line 116, in _update
    if not isinstance(iterable, collections.Iterable):
AttributeError: module 'collections' has no attribute 'Iterable'
```