### PR TITLE
Fixed typo in Printer Settings

### DIFF
--- a/octoprint_octolapse/templates/octolapse_profiles_printer_slicer_slic3r_pe.jinja2
+++ b/octoprint_octolapse/templates/octolapse_profiles_printer_slicer_slic3r_pe.jinja2
@@ -7,7 +7,7 @@
         <div>
             <div>
                 <h4>Layers and Perimeters</h4>
-                <p>Can be found in 'Printer Settings->Layers and Printers</p>
+                <p>Can be found in 'Print Settings->Layers and perimeters</p>
             </div>
             <div class="control-group">
                 <label class="control-label" for="octolapse_slic3r_pe_layer_height">Layer Height</label>


### PR DESCRIPTION
Hi!

There are two tabs in Prusa with similar names. One is "Print settings" and the other is "Printer settings". The typo had you going to the wrong tab. It confused me for a bit until I figured it out. Don't want the next person to be just as confused.

Nave a majestic day 😺