### PR TITLE
Fixing rendering bug when gcode filename contains a percent sign

### DIFF
--- a/octoprint_octolapse/render.py
+++ b/octoprint_octolapse/render.py
@@ -210,11 +210,11 @@ class RenderJobInfo(object):
         )
         self.snapshot_filename_format = os.path.basename(
             utility.get_snapshot_filename(
-                timelapse_job_info.PrintFileName, utility.SnapshotNumberFormat
+                timelapse_job_info.PrintFileName.replace('%','%%'), utility.SnapshotNumberFormat
             )
         )
         self.pre_roll_snapshot_filename_format = utility.get_pre_roll_snapshot_filename(
-            timelapse_job_info.PrintFileName, utility.SnapshotNumberFormat
+            timelapse_job_info.PrintFileName.replace('%','%%'), utility.SnapshotNumberFormat
         )
         # rendering directory path
         self.output_tokens = self._get_output_tokens(self.temporary_directory)

--- a/octoprint_octolapse/utility.py
+++ b/octoprint_octolapse/utility.py
@@ -396,12 +396,12 @@ def is_valid_temporary_extension(extension):
 
 
 def get_snapshot_filename(print_name, snapshot_number):
-    return "{0}{1}.{2}".format(print_name.replace('%','%%'), format_snapshot_number(snapshot_number), default_snapshot_extension)
+    return "{0}{1}.{2}".format(print_name, format_snapshot_number(snapshot_number), default_snapshot_extension)
 
 
 def get_pre_roll_snapshot_filename(print_name, snapshot_number):
     return "{0}{1}_{2}.{3}".format(
-        print_name.replace('%','%%'),
+        print_name,
         format_snapshot_number(snapshot_number),
         format_snapshot_number(snapshot_number),
         "jpg")

--- a/octoprint_octolapse/utility.py
+++ b/octoprint_octolapse/utility.py
@@ -396,7 +396,7 @@ def is_valid_temporary_extension(extension):
 
 
 def get_snapshot_filename(print_name, snapshot_number):
-    return "{0}{1}.{2}".format(print_name, format_snapshot_number(snapshot_number), default_snapshot_extension)
+    return "{0}{1}.{2}".format(print_name.replace('%','%%'), format_snapshot_number(snapshot_number), default_snapshot_extension)
 
 
 def get_pre_roll_snapshot_filename(print_name, snapshot_number):

--- a/octoprint_octolapse/utility.py
+++ b/octoprint_octolapse/utility.py
@@ -401,7 +401,7 @@ def get_snapshot_filename(print_name, snapshot_number):
 
 def get_pre_roll_snapshot_filename(print_name, snapshot_number):
     return "{0}{1}_{2}.{3}".format(
-        print_name,
+        print_name.replace('%','%%'),
         format_snapshot_number(snapshot_number),
         format_snapshot_number(snapshot_number),
         "jpg")


### PR DESCRIPTION
Octoprint_version: 0.4.1

Issue:
When the gcode filename contains a % in it, the rendering fails with the following error:

2022-06-27 11:54:38,651 - octolapse.render - ERROR - Rendering Error
Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_octolapse/render.py", line 1565, in _render
    self._apply_pre_post_roll()
  File "/home/pi/oprint/lib/python3.7/site-packages/octoprint_octolapse/render.py", line 2137, in _apply_pre_post_roll
    self._temp_rendering_dir, self._render_job_info.snapshot_filename_format % 0
ValueError: unsupported format character '_' (0x5f) at index 46

(In this case the filename contained "[...]_77%_[...]")

This fix will properly escape the % in the input string so that the formatting will ignore it.