### PR TITLE
changed from BACKOFF_MAX to DEFAULT_BACKOFF_MAX since it deprecated

### DIFF
--- a/octoprint_octolapse/camera.py
+++ b/octoprint_octolapse/camera.py
@@ -206,7 +206,7 @@ class CameraControl(object):
         if not no_wait:
             # join the threads, but timeout in a reasonable way
             for thread in threads:
-                thread.join(requests.packages.urllib3.util.retry.Retry.BACKOFF_MAX)
+                thread.join(requests.packages.urllib3.util.retry.Retry.DEFAULT_BACKOFF_MAX)
                 if not thread.success:
                     for error in thread.errors:
                         errors.append(error)


### PR DESCRIPTION
It needs to be changed from BACKOFF_MAX to DEFAULT_BACKOFF_MAX since it deprecated in urllib3 and causes an error after pressing a "Save changes" button in camera settings, e.g:
```
2023-08-27 14:52:56,233 - octoprint - ERROR - Exception on /plugin/octolapse/applyCameraSettings [POST]
Traceback (most recent call last):
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/flask/app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/octoprint/server/util/flask.py", line 1590, in decorated_view
    return no_firstrun_access(flask_login.login_required(func))(*args, **kwargs)
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/octoprint/server/util/flask.py", line 1613, in decorated_view
    return func(*args, **kwargs)
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/octoprint_octolapse/__init__.py", line 1259, in apply_camera_settings_request
    success, error = self.apply_camera_settings([camera_profile])
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/octoprint_octolapse/__init__.py", line 1982, in apply_camera_settings
    success, errors = camera.CameraControl.apply_camera_settings(
  File "/home/octoprint/OctoPrint/venv/lib/python3.10/site-packages/octoprint_octolapse/camera.py", line 209, in apply_camera_settings
    thread.join(requests.packages.urllib3.util.retry.Retry.BACKOFF_MAX)
AttributeError: type object 'Retry' has no attribute 'BACKOFF_MAX'
```