### PR TITLE
Button To Disable Octolapse For The Next Print

### DIFF
--- a/octoprint_octolapse/__init__.py
+++ b/octoprint_octolapse/__init__.py
@@ -1490,11 +1490,19 @@ class OctolapsePlugin(
         with OctolapsePlugin.admin_permission.require(http_exception=403):
             request_values = request.get_json()
             preprocessing_job_guid = request_values["preprocessing_job_guid"]
+            disable_for_print = request_values["disable_for_print"]
             if (
                 preprocessing_job_guid is not None and
                 str(self.preprocessing_job_guid) == preprocessing_job_guid
             ):
-                self.accept_snapshot_plan_preview(preprocessing_job_guid)
+                if (not disable_for_print):
+                    self.accept_snapshot_plan_preview(preprocessing_job_guid)
+                else:
+                    logger.info("Disabling Octolapse for the current print as per user request.")
+                    self.reset_preprocessing()
+                    self._timelapse.release_job_on_hold_lock(reset=True)
+                    self.send_snapshot_preview_complete_message()
+                    print("Disabling Octolapse for the current print as per user request!!")
                 return jsonify({
                     'success': True
                 })

--- a/octoprint_octolapse/__init__.py
+++ b/octoprint_octolapse/__init__.py
@@ -1490,19 +1490,18 @@ class OctolapsePlugin(
         with OctolapsePlugin.admin_permission.require(http_exception=403):
             request_values = request.get_json()
             preprocessing_job_guid = request_values["preprocessing_job_guid"]
-            disable_for_print = request_values["disable_for_print"]
+            disable_for_print = request_values.get("disable_for_print", False)
             if (
                 preprocessing_job_guid is not None and
                 str(self.preprocessing_job_guid) == preprocessing_job_guid
             ):
-                if (not disable_for_print):
+                if not disable_for_print:
                     self.accept_snapshot_plan_preview(preprocessing_job_guid)
                 else:
                     logger.info("Disabling Octolapse for the current print as per user request.")
                     self.reset_preprocessing()
                     self._timelapse.release_job_on_hold_lock(reset=True)
                     self.send_snapshot_preview_complete_message()
-                    print("Disabling Octolapse for the current print as per user request!!")
                 return jsonify({
                     'success': True
                 })

--- a/octoprint_octolapse/static/js/octolapse.js
+++ b/octoprint_octolapse/static/js/octolapse.js
@@ -1498,9 +1498,12 @@ $(function () {
             */
         };
 
-        self.acceptSnapshotPlanPreview = function () {
+        self.acceptSnapshotPlanPreview = function (disable_for_print) {
             //console.log("Accepting snapshot plan preview.");
-            var data = { "preprocessing_job_guid": self.preprocessing_job_guid };
+            var data = {
+                "preprocessing_job_guid": self.preprocessing_job_guid,
+                "disable_for_print": !!disable_for_print
+            };
             $.ajax({
                 url: "./plugin/octolapse/acceptSnapshotPlanPreview",
                 type: "POST",

--- a/octoprint_octolapse/static/js/octolapse.status.snapshotplan_preview.js
+++ b/octoprint_octolapse/static/js/octolapse.status.snapshotplan_preview.js
@@ -32,6 +32,7 @@ $(function() {
             dialog.$snapshotPlanPreviewDialog = $("#octolapse_snapshot_plan_preview_dialog");
             dialog.$snapshotPlanPreviewForm = dialog.$snapshotPlanPreviewDialog.find("#octolapse_snapshot_plan_preview_form");
             dialog.$cancelButton = $(".cancel", dialog.$snapshotPlanPreviewDialog);
+            dialog.$disableButton = $(".continue-disable", dialog.$snapshotPlanPreviewDialog);
             dialog.$closeIcon = $("a.close", dialog.$snapshotPlanPreviewDialog);
             dialog.$continueButton = $(".continue", dialog.$snapshotPlanPreviewDialog);
             dialog.$modalBody = dialog.$snapshotPlanPreviewDialog.find(".modal-body");
@@ -48,6 +49,11 @@ $(function() {
                 // Save the settings.
                 Octolapse.Globals.acceptSnapshotPlanPreview();
                 self.closeSnapshotPlanPreviewDialog();
+            });
+
+            dialog.$disableButton.unbind("click");
+            dialog.$disableButton.bind("click", function () {
+                Octolapse.Globals.acceptSnapshotPlanPreview(true);
             });
 
             // Prevent hiding unless the event was initiated by the hideAddEditDialog function

--- a/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
+++ b/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
@@ -38,8 +38,9 @@
                     </div>
                     <div class="modal-footer" style="bottom:0;position:relative">
                         <div class="row-fluid">
-                                <button type="button" class="span6 btn btn-default cancel input-block-level" title="Cancel the print">Cancel Print</button>
-                                <button type="button" class="span6 btn btn-primary continue input-block-level" title="Accept the snapshot plan and continue printing">
+                                <button type="button" class="span4 btn btn-default cancel input-block-level" title="Cancel the print">Cancel Print</button>
+                                <button type="button" class="span4 btn btn-default continue-disable input-block-level" title="Disable snapshots for this print and continue printing">Print without Snapshots</button>
+                                <button type="button" class="span4 btn btn-primary continue input-block-level" title="Accept the snapshot plan and continue printing">
                                     Accept and Continue <span data-bind="visible: SnapshotPlanState.autoclose">(<span data-bind="text:SnapshotPlanState.autoclose_seconds"></span> seconds)</span></button>
                             </span>
                         </div>

--- a/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
+++ b/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
@@ -39,7 +39,7 @@
                     <div class="modal-footer" style="bottom:0;position:relative">
                         <div class="row-fluid">
                                 <button type="button" class="span4 btn btn-default cancel input-block-level" title="Cancel the print">Cancel Print</button>
-                                <button type="button" class="span4 btn btn-default continue-disable input-block-level" title="Disable snapshots for this print and continue printing">Print without Snapshots</button>
+                                <button type="button" class="span4 btn btn-default continue-disable input-block-level" title="Disable Octoprint for this print and continue printing">Print without Timelapse</button>
                                 <button type="button" class="span4 btn btn-primary continue input-block-level" title="Accept the snapshot plan and continue printing">
                                     Accept and Continue <span data-bind="visible: SnapshotPlanState.autoclose">(<span data-bind="text:SnapshotPlanState.autoclose_seconds"></span> seconds)</span></button>
                             </span>

--- a/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
+++ b/octoprint_octolapse/templates/octolapse_tab_snapshot_plan_preview_popup.jinja2
@@ -39,7 +39,7 @@
                     <div class="modal-footer" style="bottom:0;position:relative">
                         <div class="row-fluid">
                                 <button type="button" class="span4 btn btn-default cancel input-block-level" title="Cancel the print">Cancel Print</button>
-                                <button type="button" class="span4 btn btn-default continue-disable input-block-level" title="Disable Octoprint for this print and continue printing">Print without Timelapse</button>
+                                <button type="button" class="span4 btn btn-default continue-disable input-block-level" title="Disable Octolapse for this print and continue printing">Print without Timelapse</button>
                                 <button type="button" class="span4 btn btn-primary continue input-block-level" title="Accept the snapshot plan and continue printing">
                                     Accept and Continue <span data-bind="visible: SnapshotPlanState.autoclose">(<span data-bind="text:SnapshotPlanState.autoclose_seconds"></span> seconds)</span></button>
                             </span>


### PR DESCRIPTION
This pull request fixes #766 by adding a button to the snapshot preview window that allows you to proceed with the next print without using Octolapse.

<img width="1440" height="617" alt="image" src="https://github.com/user-attachments/assets/3f4eb7af-dd08-4d36-9fda-e20346213f8e" />

Reasons:
* I typically want to have Octolapse enabled at all times. However, there are instances where a timelapse may not be suitable, such as with very flat prints, or when the prints are particularly delicate, and I prefer to disable Octolapse as a precaution.
* While disabling the entire plugin works, I often forget to reactivate it afterwards.
* With that button, I can quickly decide on each print.

Note: I haven't submitted many pull requests yet. Hopefully, I'm doing it correctly.